### PR TITLE
Update pg_stat_statements SQL exporter query for Postgres 13

### DIFF
--- a/sql-exporter/queries.yml
+++ b/sql-exporter/queries.yml
@@ -88,6 +88,7 @@
   help: "statement statistics"
   scope: cluster
   min_version: 9.2
+  max_version: 12
   labels:
     - "usename"
     - "datname"
@@ -139,6 +140,83 @@
           substr(regexp_replace(query, E'[\\n\\r]+', ' ', 'g' ), 1, 1024) AS query,
           calls,
           total_time,
+          rows,
+          shared_blks_hit,
+          shared_blks_read,
+          shared_blks_dirtied,
+          shared_blks_written,
+          local_blks_hit,
+          local_blks_read,
+          local_blks_dirtied,
+          local_blks_written,
+          temp_blks_read,
+          temp_blks_written
+          FROM w_pg_stat_statements pss2 JOIN pg_database pd2 ON pss2.dbid = pd2.oid
+          JOIN pg_user pu2 ON pss2.userid = pu2.usesysid
+          ORDER BY calls DESC
+          LIMIT 25
+
+- name: "pg_stat_statements"
+  help: "statement statistics"
+  scope: cluster
+  min_version: 13
+  labels:
+    - "usename"
+    - "datname"
+    - "queryid"
+    - "query"
+  values:
+    - "calls"
+    - "total_time"
+    - "total_plan_time"
+    - "total_exec_time"
+    - "rows"
+    - "shared_blks_hit"
+    - "shared_blks_read"
+    - "shared_blks_dirtied"
+    - "shared_blks_writte"
+    - "local_blks_hit"
+    - "local_blks_read"
+    - "local_blks_dirtied"
+    - "local_blks_writte"
+    - "temp_blks_read"
+    - "temp_blks_written"
+  query: >-
+          WITH w_pg_stat_statements AS ( SELECT * FROM pg_stat_statements)
+          (SELECT
+          usename::text,
+          datname::text,
+          queryid::text,
+          substr(regexp_replace(query, E'[\\n\\r]+', ' ', 'g' ), 1, 1024) AS query,
+          calls,
+          total_plan_time + total_exec_time as total_time,
+          total_plan_time,
+          total_exec_time,
+          rows,
+          shared_blks_hit,
+          shared_blks_read,
+          shared_blks_dirtied,
+          shared_blks_written,
+          local_blks_hit,
+          local_blks_read,
+          local_blks_dirtied,
+          local_blks_written,
+          temp_blks_read,
+          temp_blks_written
+          FROM w_pg_stat_statements pss JOIN pg_database pd ON pss.dbid = pd.oid
+          JOIN pg_user pu ON pss.userid = pu.usesysid
+          ORDER BY 6 DESC
+          LIMIT 25)
+          UNION
+          SELECT
+          usename::text,
+          datname::text,
+          queryid::text,
+          substr(regexp_replace(query, E'[\\n\\r]+', ' ', 'g' ), 1, 1024) AS query,
+          calls,
+          total_plan_time + total_exec_time as total_time,
+          total_plan_time,
+          total_exec_time,
           rows,
           shared_blks_hit,
           shared_blks_read,


### PR DESCRIPTION
PostgreSQL 13 has split the pg_stat_statements total_time metric into
total_plan_time and total_exec_time. This adds two new metrics for these values,
and keeps the original total_time value for backwards-compatibility with old
dashboards, during the transition.