### PR TITLE
Add bullseye support to the Vagrant Ansible playbook

### DIFF
--- a/vagrant/tasks/packages.yml
+++ b/vagrant/tasks/packages.yml
@@ -3,12 +3,14 @@
   apt_key:
     data: "{{ lookup('file', 'packages.credativ.com/aptly.key') }}"
     state: present
+  when: ansible_distribution_release == "stretch"
 
 - name: Setup credativ PostgreSQL repository
   apt_repository:
     repo: '{{ credativ_postgresql }}'
     filename: 'credativ_postgresql'
     update_cache: false
+  when: ansible_distribution_release == "stretch"
 
 # pgapt
 - name: Install pgdg Apt key
@@ -41,8 +43,15 @@
   lineinfile:
     dest: /etc/apt/sources.list
     regexp: "^deb\ .*security.debian.org.*"
+    line: "deb http://security.debian.org/debian-security {{ ansible_distribution_release }}-security main contrib"
+  when: ansible_distribution == "Debian" and ansible_distribution_release == "bullseye"
+
+- name: Setup debian security repository if not already present.
+  lineinfile:
+    dest: /etc/apt/sources.list
+    regexp: "^deb\ .*security.debian.org.*"
     line: "deb http://security.debian.org/debian-security {{ ansible_distribution_release }}/updates main contrib"
-  when: ansible_distribution == "Debian"
+  when: ansible_distribution == "Debian" and ansible_distribution_release != "bullseye"
 
 # apt
 - name: Apt Dist-Upgrade

--- a/vagrant/tasks/postgresql.yml
+++ b/vagrant/tasks/postgresql.yml
@@ -28,7 +28,18 @@
   - postgresql-contrib-{{ version }}
   - postgresql-{{ version }}-unit
   - check-postgres
-  - python-psycopg2 # for postgresql_user
+
+- name: Install PostgreSQL python2 driver
+  package:
+    name: python-psycopg2
+    state: present
+  when: ansible_distribution_release != "bullseye"
+
+- name: Install PostgreSQL python3 driver
+  package:
+    name: python3-psycopg2
+    state: present
+  when: ansible_distribution_release == "bullseye"
 
 - name: Create data volume
   file:


### PR DESCRIPTION
 * Only use packages.credativ.com on stretch (no longer available for bullseye
   and not required for buster)
 * Fix Debian security APT repository URL for bullseye
 * User python3-based psycopg2 PostgreSQL python driver for bullseye