### PR TITLE
Fix sql-exporter query typos and missing fields

### DIFF
--- a/sql-exporter/queries.yml
+++ b/sql-exporter/queries.yml
@@ -41,7 +41,7 @@
   labels:
     - "datname"
   values:
-    - "numbackends:count"
+    - "numbackends"
     - "xact_commit"
     - "xact_rollback"
     - "blks_read"
@@ -101,11 +101,11 @@
     - "shared_blks_hit"
     - "shared_blks_read"
     - "shared_blks_dirtied"
-    - "shared_blks_writte"
+    - "shared_blks_written"
     - "local_blks_hit"
     - "local_blks_read"
     - "local_blks_dirtied"
-    - "local_blks_writte"
+    - "local_blks_written"
     - "temp_blks_read"
     - "temp_blks_written"
   query: >-
@@ -174,11 +174,11 @@
     - "shared_blks_hit"
     - "shared_blks_read"
     - "shared_blks_dirtied"
-    - "shared_blks_writte"
+    - "shared_blks_written"
     - "local_blks_hit"
     - "local_blks_read"
     - "local_blks_dirtied"
-    - "local_blks_writte"
+    - "local_blks_written"
     - "temp_blks_read"
     - "temp_blks_written"
   query: >-

--- a/sql-exporter/replication.yml
+++ b/sql-exporter/replication.yml
@@ -26,7 +26,14 @@
     - "failed_count"
     - "last_failed_time"
     - "stats_reset"
-  query: SELECT archived_count, failed_count FROM pg_stat_archiver
+  query: >-
+          SELECT
+          archived_count,
+          COALESCE(EXTRACT(EPOCH FROM last_archived_time), 0.0) AS last_archived_time,
+          failed_count,
+          COALESCE(EXTRACT(EPOCH FROM last_failed_time), 0.0) AS last_failed_time,
+          COALESCE(EXTRACT(EPOCH FROM stats_reset), 0.0) AS stats_reset
+          FROM pg_stat_archiver
 
 - name: "pg_stat_replication"
   help: "replication statistics"


### PR DESCRIPTION
A couple of tiny typos and issues generated a ton of log spam. Fix that.