### PR TITLE
Overhaul Monitoring Dashboard 

### DIFF
--- a/grafana/postgresql_server_overview.json
+++ b/grafana/postgresql_server_overview.json
@@ -3805,7 +3805,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by (datname) (sql_pg_stat_activity{job=~'$job', host=~'$host', sql_job=~'$cluster', col='max_tx_duration'})",
+          "expr": "max by (datname) (sql_pg_stat_activity{job=~'$job', host=~'$host', sql_job=~'$cluster', col='max_tx_duration', datname=~'$datname'})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{datname}}",

--- a/grafana/postgresql_server_overview.json
+++ b/grafana/postgresql_server_overview.json
@@ -6379,7 +6379,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 11,
         "w": 8,
         "x": 0,
         "y": 137
@@ -6395,7 +6395,7 @@
         "max": false,
         "min": false,
         "rightSide": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -6483,7 +6483,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 11,
         "w": 8,
         "x": 8,
         "y": 137
@@ -6499,7 +6499,7 @@
         "max": false,
         "min": false,
         "rightSide": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -6587,7 +6587,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 11,
         "w": 8,
         "x": 16,
         "y": 137
@@ -6603,7 +6603,7 @@
         "max": false,
         "min": false,
         "rightSide": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -6690,7 +6690,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 145
+        "y": 148
       },
       "id": 58,
       "links": [],

--- a/grafana/postgresql_server_overview.json
+++ b/grafana/postgresql_server_overview.json
@@ -5766,7 +5766,7 @@
     {
       "columns": [],
       "datasource": "prometheus",
-      "description": "Shows how the total time increase over the last $rate_interval.",
+      "description": "Shows how long statements took in the chosen time period.",
       "fontSize": "100%",
       "gridPos": {
         "h": 12,
@@ -6020,8 +6020,9 @@
       ],
       "targets": [
         {
-          "expr": "increase(sql_pg_stat_statements{job=~'$job', host=~'$host', sql_job=~'$cluster', host=~'$host', col='total_time', datname=~'$datname'}[$rate_interval])",
+          "expr": "topk($ntop_relations, increase(sql_pg_stat_statements{job=~'$job', host=~'$host', sql_job=~'$cluster', host=~'$host', col='total_time', datname=~'$datname'}[$__range]))",
           "format": "table",
+          "instant": true,
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -6029,10 +6030,35 @@
           "step": 2
         }
       ],
-      "timeFrom": "1s",
+      "timeFrom": null,
       "timeShift": null,
-      "title": "Statements by Total Time Increase [$rate_interval] - $datname",
+      "title": "Top $ntop_relations Statements by Total Time - $datname",
       "transform": "table",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Time": 0,
+              "Value": 10,
+              "col": 1,
+              "database": 2,
+              "datname": 3,
+              "driver": 6,
+              "host": 7,
+              "instance": 8,
+              "job": 9,
+              "query": 11,
+              "queryid": 12,
+              "sql_job": 13,
+              "usename": 4,
+              "user": 5
+            },
+            "renameByName": {}
+          }
+        }
+      ],
       "type": "table"
     }
   ],

--- a/grafana/postgresql_server_overview.json
+++ b/grafana/postgresql_server_overview.json
@@ -3742,24 +3742,30 @@
         },
         "overrides": []
       },
-      "fill": 5,
+      "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 12,
         "x": 0,
         "y": 71
       },
       "hiddenSeries": false,
-      "id": 8,
+      "id": 6,
       "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": true,
         "min": false,
+        "rightSide": false,
         "show": true,
+        "sort": "avg",
+        "sortDesc": false,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -3773,13 +3779,39 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:5500",
+          "alias": "waiting",
+          "color": "#F2495C"
+        },
+        {
+          "$$hashKey": "object:5508",
+          "alias": "idle in transaction",
+          "color": "#FF9830"
+        },
+        {
+          "$$hashKey": "object:5516",
+          "alias": "active",
+          "color": "#73BF69"
+        },
+        {
+          "$$hashKey": "object:5530",
+          "alias": "idle",
+          "color": "#5794F2"
+        },
+        {
+          "$$hashKey": "object:743",
+          "alias": "idle in transaction (aborted)",
+          "color": "#FADE2A"
+        }
+      ],
       "spaceLength": 10,
       "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (state) (sql_pg_stat_activity{job=~'$job', host=~'$host', sql_job=~'$cluster', col='count', datname=~'$datname'})",
+          "expr": "sort_desc(sum by (state) (sql_pg_stat_activity{job=~'$job', host=~'$host', sql_job=~'$cluster', col='count', datname=~'$datname'}))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3797,9 +3829,10 @@
       "title": "Connections by State - $datname",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
+      "transformations": [],
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -3810,6 +3843,8 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:5021",
+          "decimals": 0,
           "format": "short",
           "label": "",
           "logBase": 1,
@@ -3818,8 +3853,10 @@
           "show": true
         },
         {
+          "$$hashKey": "object:5022",
+          "decimals": 3,
           "format": "short",
-          "label": null,
+          "label": "",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -3843,10 +3880,10 @@
         },
         "overrides": []
       },
-      "fill": 5,
+      "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 12,
         "x": 12,
         "y": 71
@@ -3874,7 +3911,11 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1166"
+        }
+      ],
       "spaceLength": 10,
       "stack": true,
       "steppedLine": false,
@@ -3910,6 +3951,8 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:715",
+          "decimals": 0,
           "format": "short",
           "label": "",
           "logBase": 1,
@@ -3918,6 +3961,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:716",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -3938,7 +3982,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 78
+        "y": 80
       },
       "id": 93,
       "panels": [],
@@ -3963,7 +4007,7 @@
         "h": 7,
         "w": 9,
         "x": 0,
-        "y": 79
+        "y": 81
       },
       "hiddenSeries": false,
       "id": 10,
@@ -4078,7 +4122,7 @@
         "h": 7,
         "w": 8,
         "x": 9,
-        "y": 79
+        "y": 81
       },
       "hiddenSeries": false,
       "id": 91,
@@ -4179,7 +4223,7 @@
         "h": 7,
         "w": 7,
         "x": 17,
-        "y": 79
+        "y": 81
       },
       "hiddenSeries": false,
       "id": 42,
@@ -4277,7 +4321,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 86
+        "y": 88
       },
       "id": 78,
       "panels": [],
@@ -4298,12 +4342,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 87
+        "y": 89
       },
+      "hiddenSeries": false,
       "id": 24,
       "legend": {
         "alignAsTable": false,
@@ -4321,6 +4367,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 2,
@@ -4382,6 +4431,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Read / Change Stats [$rate_interval] - ($datname)",
       "tooltip": {
@@ -4433,12 +4483,14 @@
         "overrides": []
       },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 87
+        "y": 89
       },
+      "hiddenSeries": false,
       "id": 16,
       "legend": {
         "avg": false,
@@ -4455,6 +4507,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -4478,6 +4533,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Live Tuples (top $ntop_relations) - $datname",
       "tooltip": {
@@ -4529,12 +4585,14 @@
         "overrides": []
       },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 87
+        "y": 89
       },
+      "hiddenSeries": false,
       "id": 12,
       "legend": {
         "avg": false,
@@ -4551,6 +4609,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -4574,6 +4635,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Dead Tuples (top $ntop_relations) - $datname",
       "tooltip": {
@@ -4619,7 +4681,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 94
+        "y": 96
       },
       "id": 77,
       "panels": [],
@@ -4640,12 +4702,14 @@
         "overrides": []
       },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 9,
         "x": 0,
-        "y": 95
+        "y": 97
       },
+      "hiddenSeries": false,
       "id": 5,
       "legend": {
         "avg": false,
@@ -4662,6 +4726,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -4685,6 +4752,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Sequential Scan Tuples [$rate_interval] (top $ntop_relations) - $datname",
       "tooltip": {
@@ -4736,12 +4804,14 @@
         "overrides": []
       },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 9,
         "x": 9,
-        "y": 95
+        "y": 97
       },
+      "hiddenSeries": false,
       "id": 55,
       "legend": {
         "avg": false,
@@ -4758,6 +4828,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -4781,6 +4854,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Seq/Index Tuple Ratio [$rate_interval] (top $ntop_relations) - $datname",
       "tooltip": {
@@ -4832,12 +4906,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 95
+        "y": 97
       },
+      "hiddenSeries": false,
       "id": 27,
       "legend": {
         "avg": false,
@@ -4852,6 +4928,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -4881,6 +4960,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Buffer Hits and Misses [$rate_interval] - $datname",
       "tooltip": {
@@ -4926,7 +5006,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 103
+        "y": 105
       },
       "id": 80,
       "panels": [],
@@ -4947,12 +5027,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 7,
         "x": 0,
-        "y": 104
+        "y": 106
       },
+      "hiddenSeries": false,
       "id": 26,
       "legend": {
         "alignAsTable": false,
@@ -4971,6 +5053,9 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -5002,6 +5087,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "WAL/Checkpoint Traffic [$rate_interval]",
       "tooltip": {
@@ -5053,12 +5139,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 9,
         "x": 7,
-        "y": 104
+        "y": 106
       },
+      "hiddenSeries": false,
       "id": 29,
       "legend": {
         "avg": false,
@@ -5073,6 +5161,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -5107,6 +5198,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Checkpoints per Minute",
       "tooltip": {
@@ -5183,12 +5275,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 104
+        "y": 106
       },
+      "hiddenSeries": false,
       "id": 31,
       "legend": {
         "avg": false,
@@ -5203,6 +5297,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -5226,6 +5323,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "WAL since last Checkpoint",
       "tooltip": {
@@ -5271,7 +5369,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 111
+        "y": 113
       },
       "id": 81,
       "panels": [],
@@ -5292,12 +5390,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 10,
         "x": 0,
-        "y": 112
+        "y": 114
       },
+      "hiddenSeries": false,
       "id": 30,
       "legend": {
         "alignAsTable": false,
@@ -5316,6 +5416,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -5339,6 +5442,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Maintenance Operations per Minute [$rate_interval] - $datname",
       "tooltip": {
@@ -5390,12 +5494,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 9,
         "x": 10,
-        "y": 112
+        "y": 114
       },
+      "hiddenSeries": false,
       "id": 53,
       "legend": {
         "avg": false,
@@ -5412,6 +5518,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -5435,6 +5544,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Maintenance Counters - $datname",
       "tooltip": {
@@ -5487,12 +5597,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 5,
         "x": 19,
-        "y": 112
+        "y": 114
       },
+      "hiddenSeries": false,
       "id": 54,
       "legend": {
         "alignAsTable": false,
@@ -5509,6 +5621,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -5532,6 +5647,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Database Freeze Age - $datname",
       "tooltip": {
@@ -5577,7 +5693,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 119
+        "y": 121
       },
       "id": 85,
       "panels": [],
@@ -5599,12 +5715,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 7,
         "x": 0,
-        "y": 120
+        "y": 122
       },
+      "hiddenSeries": false,
       "id": 51,
       "legend": {
         "avg": false,
@@ -5619,6 +5737,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -5640,6 +5761,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "WAL Files Ready",
       "tooltip": {
@@ -5694,12 +5816,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 7,
         "x": 7,
-        "y": 120
+        "y": 122
       },
+      "hiddenSeries": false,
       "id": 47,
       "legend": {
         "avg": false,
@@ -5714,6 +5838,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -5738,6 +5865,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "WAL Archiving per Minute [$rate_interval]",
       "tooltip": {
@@ -5794,12 +5922,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 10,
         "x": 14,
-        "y": 120
+        "y": 122
       },
+      "hiddenSeries": false,
       "id": 61,
       "legend": {
         "alignAsTable": false,
@@ -5818,6 +5948,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -5865,6 +5998,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Replication Lag",
       "tooltip": {
@@ -5910,7 +6044,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 127
+        "y": 129
       },
       "id": 83,
       "panels": [],
@@ -5932,12 +6066,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 128
+        "y": 130
       },
+      "hiddenSeries": false,
       "id": 57,
       "legend": {
         "alignAsTable": false,
@@ -5956,6 +6092,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -5978,6 +6117,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Top $ntop_relations Statements by Average Execution Time [$rate_interval] - $datname",
       "tooltip": {
@@ -6030,12 +6170,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 128
+        "y": 130
       },
+      "hiddenSeries": false,
       "id": 98,
       "legend": {
         "alignAsTable": false,
@@ -6054,6 +6196,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -6076,6 +6221,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Top $ntop_relations Statements by Total Time [$rate_interval] - $datname",
       "tooltip": {
@@ -6128,12 +6274,14 @@
         "overrides": []
       },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 128
+        "y": 130
       },
+      "hiddenSeries": false,
       "id": 59,
       "legend": {
         "alignAsTable": false,
@@ -6152,6 +6300,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
       "pluginVersion": "7.4.3",
       "pointradius": 5,
@@ -6174,6 +6325,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Top $ntop_relations Statements by Calls [$rate_interval] - $datname",
       "tooltip": {
@@ -6227,7 +6379,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 136
+        "y": 138
       },
       "id": 58,
       "links": [],

--- a/grafana/postgresql_server_overview.json
+++ b/grafana/postgresql_server_overview.json
@@ -70,6 +70,955 @@
         "x": 0,
         "y": 0
       },
+      "id": 100,
+      "panels": [],
+      "title": "Settings",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 0,
+        "y": 1
+      },
+      "id": 119,
+      "interval": null,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "name"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "sql_server{host=~'$host',sql_job=~'$cluster',col=\"server_start_time\"}",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{server_version}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Version",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 2,
+        "y": 1
+      },
+      "id": 115,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "count(count(node_cpu_seconds_total) without (mode)) without (cpu)",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "# Cores",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 4,
+        "y": 1
+      },
+      "id": 112,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "node_memory_MemTotal_bytes",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Memory",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 110,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sql_settings{col=\"max_connections\",host=~'$host',sql_job=~'$cluster'}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Max Connections",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "id": 104,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sql_settings{col=\"work_mem\",host=~'$host',sql_job=~'$cluster'}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Work Mem",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "id": 105,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sql_settings{col=\"shared_buffers\",host=~'$host',sql_job=~'$cluster'}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Shared Buffers",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 15,
+        "y": 1
+      },
+      "id": 109,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sql_settings{col=\"max_wal_size\",host=~'$host',sql_job=~'$cluster'}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Max WAL Size",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [
+            {
+              "from": "",
+              "id": 1,
+              "text": "Off",
+              "to": "",
+              "type": 1,
+              "value": "0"
+            },
+            {
+              "from": "",
+              "id": 2,
+              "text": "On",
+              "to": "",
+              "type": 1,
+              "value": "1"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "id": 102,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sql_settings{col=\"data_checksums\",host=~'$host',sql_job=~'$cluster'}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Data Checksums",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 114,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sum by (checksum_failures) (sql_pg_stat_database{col=\"checksum_failures\",host=~'$host',sql_job=~'$cluster'})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Checksum Failures",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 106,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sql_server{col=\"server_start_time\", host=~'$host',sql_job=~'$cluster'} * 1000",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Server Start Time",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 4
+      },
+      "id": 120,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sql_settings{col=\"max_worker_processes\",host=~'$host',sql_job=~'$cluster'}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Max Worker Processes",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 9,
+        "y": 4
+      },
+      "id": 107,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sql_settings{col=\"maintenance_work_mem\",host=~'$host',sql_job=~'$cluster'}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Maintenance Work Mem",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 12,
+        "y": 4
+      },
+      "id": 108,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sql_settings{col=\"effective_cache_size\",host=~'$host',sql_job=~'$cluster'}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Effective Cache Size",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 15,
+        "y": 4
+      },
+      "id": 111,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sql_settings{col=\"checkpoint_timeout\",host=~'$host',sql_job=~'$cluster'}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Checkpoint Timeout",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [
+            {
+              "from": "",
+              "id": 1,
+              "text": "Off",
+              "to": "",
+              "type": 1,
+              "value": "0"
+            },
+            {
+              "from": "",
+              "id": 2,
+              "text": "On",
+              "to": "",
+              "type": 1,
+              "value": "1"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 18,
+        "y": 4
+      },
+      "id": 103,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "sql_settings{col=\"jit\",host=~'$host',sql_job=~'$cluster'}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "JIT",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(255, 255, 255)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 21,
+        "y": 4
+      },
+      "id": 113,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "node_vmstat_oom_kill",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Out-of-Memory Kills",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
       "id": 69,
       "panels": [],
       "repeat": null,
@@ -100,7 +1049,7 @@
         "h": 6,
         "w": 4,
         "x": 0,
-        "y": 1
+        "y": 8
       },
       "id": 35,
       "interval": null,
@@ -186,7 +1135,7 @@
         "h": 6,
         "w": 4,
         "x": 4,
-        "y": 1
+        "y": 8
       },
       "id": 34,
       "interval": null,
@@ -273,7 +1222,7 @@
         "h": 6,
         "w": 4,
         "x": 8,
-        "y": 1
+        "y": 8
       },
       "id": 36,
       "interval": null,
@@ -360,7 +1309,7 @@
         "h": 6,
         "w": 4,
         "x": 12,
-        "y": 1
+        "y": 8
       },
       "id": 38,
       "interval": null,
@@ -445,7 +1394,7 @@
         "h": 6,
         "w": 4,
         "x": 16,
-        "y": 1
+        "y": 8
       },
       "id": 39,
       "interval": null,
@@ -530,7 +1479,7 @@
         "h": 6,
         "w": 4,
         "x": 20,
-        "y": 1
+        "y": 8
       },
       "id": 41,
       "interval": null,
@@ -616,7 +1565,7 @@
         "h": 6,
         "w": 4,
         "x": 0,
-        "y": 7
+        "y": 14
       },
       "id": 45,
       "interval": null,
@@ -701,7 +1650,7 @@
         "h": 6,
         "w": 4,
         "x": 4,
-        "y": 7
+        "y": 14
       },
       "id": 50,
       "interval": null,
@@ -786,7 +1735,7 @@
         "h": 6,
         "w": 4,
         "x": 8,
-        "y": 7
+        "y": 14
       },
       "id": 46,
       "interval": null,
@@ -871,7 +1820,7 @@
         "h": 6,
         "w": 4,
         "x": 12,
-        "y": 7
+        "y": 14
       },
       "id": 43,
       "interval": null,
@@ -956,7 +1905,7 @@
         "h": 6,
         "w": 4,
         "x": 16,
-        "y": 7
+        "y": 14
       },
       "id": 49,
       "interval": null,
@@ -1041,7 +1990,7 @@
         "h": 6,
         "w": 4,
         "x": 20,
-        "y": 7
+        "y": 14
       },
       "id": 64,
       "interval": null,
@@ -1110,7 +2059,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 20
       },
       "id": 70,
       "panels": [],
@@ -1130,7 +2079,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 21
       },
       "id": 1,
       "legend": {
@@ -1221,7 +2170,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 14
+        "y": 21
       },
       "id": 2,
       "legend": {
@@ -1305,7 +2254,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 28
       },
       "id": 71,
       "panels": [],
@@ -1329,7 +2278,7 @@
         "h": 7,
         "w": 14,
         "x": 0,
-        "y": 22
+        "y": 29
       },
       "id": 33,
       "legend": {
@@ -1453,7 +2402,7 @@
         "h": 7,
         "w": 6,
         "x": 14,
-        "y": 22
+        "y": 29
       },
       "id": 23,
       "legend": {
@@ -1546,7 +2495,7 @@
         "h": 7,
         "w": 4,
         "x": 20,
-        "y": 22
+        "y": 29
       },
       "id": 19,
       "legend": {
@@ -1644,7 +2593,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 36
       },
       "id": 72,
       "panels": [],
@@ -1666,7 +2615,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 30
+        "y": 37
       },
       "id": 32,
       "legend": {
@@ -1773,7 +2722,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 44
       },
       "id": 73,
       "panels": [],
@@ -1793,7 +2742,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 38
+        "y": 45
       },
       "height": "",
       "id": 4,
@@ -1913,7 +2862,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 38
+        "y": 45
       },
       "height": "",
       "id": 3,
@@ -2013,7 +2962,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 38
+        "y": 45
       },
       "height": "",
       "id": 7,
@@ -2109,7 +3058,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 54
       },
       "id": 74,
       "panels": [],
@@ -2129,7 +3078,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 48
+        "y": 55
       },
       "id": 20,
       "legend": {
@@ -2227,7 +3176,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 48
+        "y": 55
       },
       "id": 21,
       "legend": {
@@ -2319,7 +3268,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 62
       },
       "id": 76,
       "panels": [],
@@ -2338,7 +3287,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 56
+        "y": 63
       },
       "id": 67,
       "legend": {
@@ -2426,7 +3375,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 56
+        "y": 63
       },
       "id": 68,
       "legend": {
@@ -2509,7 +3458,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 70
       },
       "id": 75,
       "panels": [],
@@ -2528,7 +3477,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 64
+        "y": 71
       },
       "id": 8,
       "legend": {
@@ -2616,7 +3565,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 64
+        "y": 73
       },
       "id": 9,
       "legend": {
@@ -2698,7 +3647,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 71
+        "y": 78
       },
       "id": 93,
       "panels": [],
@@ -2716,7 +3665,7 @@
         "h": 7,
         "w": 9,
         "x": 0,
-        "y": 72
+        "y": 79
       },
       "id": 10,
       "legend": {
@@ -2818,7 +3767,7 @@
         "h": 7,
         "w": 8,
         "x": 9,
-        "y": 72
+        "y": 79
       },
       "id": 91,
       "legend": {
@@ -2905,7 +3854,7 @@
         "h": 7,
         "w": 7,
         "x": 17,
-        "y": 72
+        "y": 79
       },
       "id": 42,
       "legend": {
@@ -2996,7 +3945,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 79
+        "y": 86
       },
       "id": 78,
       "panels": [],
@@ -3015,7 +3964,7 @@
         "h": 7,
         "w": 10,
         "x": 0,
-        "y": 80
+        "y": 87
       },
       "id": 24,
       "legend": {
@@ -3122,7 +4071,7 @@
         "h": 7,
         "w": 7,
         "x": 10,
-        "y": 80
+        "y": 87
       },
       "id": 16,
       "legend": {
@@ -3211,7 +4160,7 @@
         "h": 7,
         "w": 7,
         "x": 17,
-        "y": 80
+        "y": 87
       },
       "id": 12,
       "legend": {
@@ -3295,7 +4244,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 87
+        "y": 94
       },
       "id": 77,
       "panels": [],
@@ -3314,7 +4263,7 @@
         "h": 8,
         "w": 9,
         "x": 0,
-        "y": 88
+        "y": 95
       },
       "id": 5,
       "legend": {
@@ -3403,7 +4352,7 @@
         "h": 8,
         "w": 9,
         "x": 9,
-        "y": 88
+        "y": 95
       },
       "id": 55,
       "legend": {
@@ -3492,7 +4441,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 88
+        "y": 95
       },
       "id": 27,
       "legend": {
@@ -3580,7 +4529,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 96
+        "y": 103
       },
       "id": 80,
       "panels": [],
@@ -3599,7 +4548,7 @@
         "h": 7,
         "w": 7,
         "x": 0,
-        "y": 97
+        "y": 104
       },
       "id": 26,
       "legend": {
@@ -3690,7 +4639,7 @@
         "h": 7,
         "w": 9,
         "x": 7,
-        "y": 97
+        "y": 104
       },
       "id": 29,
       "legend": {
@@ -3779,7 +4728,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 97
+        "y": 104
       },
       "id": 31,
       "legend": {
@@ -3862,7 +4811,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 104
+        "y": 111
       },
       "id": 81,
       "panels": [],
@@ -3881,7 +4830,7 @@
         "h": 7,
         "w": 10,
         "x": 0,
-        "y": 105
+        "y": 112
       },
       "id": 30,
       "legend": {
@@ -3972,7 +4921,7 @@
         "h": 7,
         "w": 9,
         "x": 10,
-        "y": 105
+        "y": 112
       },
       "id": 53,
       "legend": {
@@ -4062,7 +5011,7 @@
         "h": 7,
         "w": 5,
         "x": 19,
-        "y": 105
+        "y": 112
       },
       "id": 54,
       "legend": {
@@ -4146,7 +5095,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 112
+        "y": 119
       },
       "id": 85,
       "panels": [],
@@ -4166,7 +5115,7 @@
         "h": 7,
         "w": 7,
         "x": 0,
-        "y": 113
+        "y": 120
       },
       "id": 51,
       "legend": {
@@ -4254,7 +5203,7 @@
         "h": 7,
         "w": 7,
         "x": 7,
-        "y": 113
+        "y": 120
       },
       "id": 47,
       "legend": {
@@ -4347,7 +5296,7 @@
         "h": 7,
         "w": 10,
         "x": 14,
-        "y": 113
+        "y": 120
       },
       "id": 61,
       "legend": {
@@ -4457,7 +5406,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 120
+        "y": 127
       },
       "id": 83,
       "panels": [],
@@ -4477,7 +5426,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 121
+        "y": 128
       },
       "id": 57,
       "legend": {
@@ -4568,7 +5517,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 121
+        "y": 128
       },
       "id": 98,
       "legend": {
@@ -4659,7 +5608,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 121
+        "y": 128
       },
       "id": 59,
       "legend": {
@@ -4747,7 +5696,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 129
+        "y": 136
       },
       "id": 58,
       "links": [],

--- a/grafana/postgresql_server_overview.json
+++ b/grafana/postgresql_server_overview.json
@@ -1049,6 +1049,12 @@
       "datasource": "prometheus",
       "decimals": 1,
       "description": "The CPU usage, rate over $rate_interval.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percent",
       "gauge": {
         "maxValue": 100,
@@ -1135,6 +1141,12 @@
       "datasource": "prometheus",
       "decimals": 1,
       "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percentunit",
       "gauge": {
         "maxValue": 1,
@@ -1222,6 +1234,12 @@
       "datasource": "prometheus",
       "decimals": 1,
       "description": "Shows the percentage of used storage on the most used mount.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percentunit",
       "gauge": {
         "maxValue": 1,
@@ -1309,6 +1327,12 @@
       "datasource": "prometheus",
       "decimals": null,
       "description": "Percentage of swap spaced used on system",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percentunit",
       "gauge": {
         "maxValue": 1,
@@ -1394,6 +1418,12 @@
       "datasource": "prometheus",
       "decimals": 2,
       "description": "Age of oldest XID in percent of autovacuum_max_freeze_age (default: 200 M)\n\nAt 100%, tables will be frozen by autovacuum. Values over 100% indicate autovacuum is not keeping up.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percentunit",
       "gauge": {
         "maxValue": 2,
@@ -1479,6 +1509,12 @@
       "datasource": "prometheus",
       "decimals": 2,
       "description": "The used connections in relation to the limit (reduced by superuser_reserved_connections).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percentunit",
       "gauge": {
         "maxValue": 1,
@@ -1565,6 +1601,12 @@
       "datasource": "prometheus",
       "decimals": 0,
       "description": "Number of WAL files that still need to be archived.\n\nCan grow under write load but should not increase over longer periods of time.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 3000,
@@ -1650,6 +1692,12 @@
       "datasource": "prometheus",
       "decimals": 0,
       "description": "The amount of WAL data that still needs to be archived.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "MBs",
       "gauge": {
         "maxValue": 15,
@@ -1735,6 +1783,12 @@
       "datasource": "prometheus",
       "decimals": 2,
       "description": "Shows the rate/increase in failed archive actions.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 3,
@@ -1820,6 +1874,12 @@
       "datasource": "prometheus",
       "decimals": null,
       "description": "Active WAL senders in relation to max_wal_senders.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percentunit",
       "gauge": {
         "maxValue": 1,
@@ -1905,6 +1965,12 @@
       ],
       "datasource": "prometheus",
       "description": "Shows the used prepared transactions in relation to max_prepared_transactions.\n\n'N/A' if not used.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percentunit",
       "gauge": {
         "maxValue": 1,
@@ -1990,6 +2056,12 @@
       "datasource": "prometheus",
       "decimals": 1,
       "description": "Shows the maximum of send_lag_bytes, flush_lag_bytes, replay_lag_bytes over all connected streaming receivers.\nThis is not a sufficient way to monitor if a standby is up to date!\nCan only give a hint if streaming is delayed.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "decbytes",
       "gauge": {
         "maxValue": 1000000000,
@@ -2067,6 +2139,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2086,13 +2159,21 @@
       "dashes": false,
       "datasource": "prometheus",
       "decimals": 2,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
         "y": 21
       },
+      "hiddenSeries": false,
       "id": 1,
       "legend": {
         "alignAsTable": false,
@@ -2111,7 +2192,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2133,6 +2218,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Usage (by mode) [$rate_interval]",
       "tooltip": {
@@ -2177,13 +2263,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
         "y": 21
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "avg": false,
@@ -2200,7 +2294,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2222,6 +2320,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Usage (by core) [$rate_interval]",
       "tooltip": {
@@ -2262,6 +2361,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2285,13 +2385,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 6,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 14,
         "x": 0,
         "y": 29
       },
+      "hiddenSeries": false,
       "id": 33,
       "legend": {
         "alignAsTable": false,
@@ -2310,7 +2418,11 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2362,6 +2474,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Distribution",
       "tooltip": {
@@ -2409,13 +2522,21 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "Modified memory that needs to be written back to permanent storage.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 6,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 6,
         "x": 14,
         "y": 29
       },
+      "hiddenSeries": false,
       "id": 23,
       "legend": {
         "avg": false,
@@ -2430,7 +2551,11 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2453,6 +2578,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Memory Dirty",
       "tooltip": {
@@ -2502,13 +2628,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 4,
         "x": 20,
         "y": 29
       },
+      "hiddenSeries": false,
       "id": 19,
       "legend": {
         "avg": false,
@@ -2523,7 +2657,11 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2560,6 +2698,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Swap Usage",
       "tooltip": {
@@ -2567,7 +2706,6 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": false,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -2601,6 +2739,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2622,13 +2761,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 8,
+        "w": 24,
         "x": 0,
         "y": 37
       },
+      "hiddenSeries": false,
       "id": 32,
       "legend": {
         "avg": false,
@@ -2642,14 +2789,24 @@
       "lines": true,
       "linewidth": 2,
       "links": [],
-      "minSpan": null,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "repeat": "filesystem",
       "repeatDirection": "h",
+      "scopedVars": {
+        "filesystem": {
+          "selected": false,
+          "text": "/",
+          "value": "/"
+        }
+      },
       "seriesOverrides": [
         {
           "alias": "/Used.*$/",
@@ -2689,6 +2846,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Filesystem - \"$filesystem\"",
       "tooltip": {
@@ -2696,7 +2854,6 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": false,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -2730,6 +2887,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2749,7 +2907,14 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "Reads are shown above the \nzero line (>0) and writes are shown below (<0).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
@@ -2757,6 +2922,7 @@
         "y": 45
       },
       "height": "",
+      "hiddenSeries": false,
       "id": 4,
       "legend": {
         "alignAsTable": false,
@@ -2775,7 +2941,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2824,6 +2994,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Read/Write (IOPS) [$rate_interval] - $disk",
       "tooltip": {
@@ -2869,7 +3040,14 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "Reads are shown above the \nzero line (>0) and writes are shown below (<0).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
@@ -2877,6 +3055,7 @@
         "y": 45
       },
       "height": "",
+      "hiddenSeries": false,
       "id": 3,
       "legend": {
         "avg": true,
@@ -2893,7 +3072,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -2924,6 +3107,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Read/Write (bytes) [$rate_interval] - $disk",
       "tooltip": {
@@ -2969,7 +3153,14 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "Reads are shown above the \nzero line (>0) and writes are shown below (<0).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
@@ -2977,6 +3168,7 @@
         "y": 45
       },
       "height": "",
+      "hiddenSeries": false,
       "id": 7,
       "legend": {
         "avg": true,
@@ -2993,7 +3185,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3026,6 +3222,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Read/Write Time [$rate_interval] - $disk",
       "tooltip": {
@@ -3066,6 +3263,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3085,13 +3283,21 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "RX is shown above the \nzero line (>0) and TX is shown below (<0).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 3,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
         "y": 55
       },
+      "hiddenSeries": false,
       "id": 20,
       "legend": {
         "avg": false,
@@ -3106,7 +3312,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3138,6 +3348,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network Traffic [$rate_interval] - $interface",
       "tooltip": {
@@ -3183,13 +3394,21 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "RX is shown above the \nzero line (>0) and TX is shown below (<0).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 3,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
         "y": 55
       },
+      "hiddenSeries": false,
       "id": 21,
       "legend": {
         "avg": false,
@@ -3204,7 +3423,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3236,6 +3459,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network Packets [$rate_interval] - $interface",
       "tooltip": {
@@ -3276,6 +3500,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3294,13 +3519,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
         "y": 63
       },
+      "hiddenSeries": false,
       "id": 67,
       "legend": {
         "avg": false,
@@ -3317,7 +3550,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3338,6 +3575,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Database Growth [$rate_interval] - $datname",
       "tooltip": {
@@ -3382,13 +3620,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
         "y": 63
       },
+      "hiddenSeries": false,
       "id": 68,
       "legend": {
         "avg": true,
@@ -3405,7 +3651,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3426,6 +3676,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Database Size - $datname",
       "tooltip": {
@@ -3466,6 +3717,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3484,13 +3736,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
         "y": 71
       },
+      "hiddenSeries": false,
       "id": 8,
       "legend": {
         "avg": false,
@@ -3505,7 +3765,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3528,6 +3792,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Connections by State - $datname",
       "tooltip": {
@@ -3572,13 +3837,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 5,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 73
+        "y": 71
       },
+      "hiddenSeries": false,
       "id": 9,
       "legend": {
         "avg": false,
@@ -3593,7 +3866,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3615,6 +3892,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Connections by Database - $datname",
       "tooltip": {
@@ -3655,6 +3933,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3672,13 +3951,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 9,
         "x": 0,
         "y": 79
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "avg": false,
@@ -3693,7 +3980,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3730,6 +4021,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Transactions by database [$rate_interval] - $datname",
       "tooltip": {
@@ -3774,13 +4066,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 9,
         "y": 79
       },
+      "hiddenSeries": false,
       "id": 91,
       "legend": {
         "avg": false,
@@ -3795,7 +4095,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3815,6 +4119,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Maximum Transaction Age",
       "tooltip": {
@@ -3862,13 +4167,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 3,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 7,
         "x": 17,
         "y": 79
       },
+      "hiddenSeries": false,
       "id": 42,
       "legend": {
         "avg": false,
@@ -3883,7 +4196,11 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -3914,6 +4231,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Locks - $datname",
       "tooltip": {
@@ -3954,6 +4272,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3972,6 +4291,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -3997,6 +4322,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4100,6 +4426,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 5,
       "gridPos": {
         "h": 7,
@@ -4124,6 +4456,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4189,6 +4522,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 5,
       "gridPos": {
         "h": 7,
@@ -4213,6 +4552,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4274,6 +4614,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4292,6 +4633,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 5,
       "gridPos": {
         "h": 8,
@@ -4316,6 +4663,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4381,6 +4729,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 5,
       "gridPos": {
         "h": 8,
@@ -4405,6 +4759,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4470,6 +4825,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -4492,6 +4853,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4559,6 +4921,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4577,6 +4940,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -4603,6 +4972,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4676,6 +5046,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -4698,6 +5074,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4799,6 +5176,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -4821,6 +5204,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4849,7 +5233,6 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": false,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -4883,6 +5266,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4901,6 +5285,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -4927,6 +5317,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -4992,6 +5383,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -5016,6 +5413,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -5082,6 +5480,12 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "Age of oldest XID in database\n\nWhen reaching autovacuum_max_freeze_age (default: 200 M), tables will be frozen by autovacuum.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -5106,6 +5510,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -5167,6 +5572,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -5186,6 +5592,12 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "Number of WAL files that still need to be archived.\n\nCan grow under write load but should not increase over longer periods of time.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -5208,6 +5620,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -5274,6 +5687,12 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "Successful and failed archive commands per minute.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -5296,6 +5715,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -5367,6 +5787,12 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "The amount of data a stream receiver like a standby server lags behind the master.\n\nsend_lag: Data that still needs to be send (should be small).\n\nflush_lag: Data that was received but must be flushed to persistent storage (this data can be lost if the standby is terminated).\n\nreplay_lag: Data that still needs to be replayed by PostgreSQL on the standby (can lag behind during writes in asynchronous configurations).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -5393,6 +5819,7 @@
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -5478,6 +5905,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -5497,6 +5925,12 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "Statement average execution time",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -5523,6 +5957,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -5588,6 +6023,12 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "Statement execution time per second",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -5614,6 +6055,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -5679,6 +6121,12 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "Statements called per second",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -5705,6 +6153,7 @@
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
+      "pluginVersion": "7.4.3",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -5767,6 +6216,12 @@
       "columns": [],
       "datasource": "prometheus",
       "description": "Shows how long statements took in the chosen time period.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 12,
@@ -5786,12 +6241,14 @@
       "styles": [
         {
           "alias": "Time",
+          "align": "auto",
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "pattern": "Time",
           "type": "hidden"
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -5807,6 +6264,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -5822,6 +6280,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -5837,6 +6296,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -5852,6 +6312,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -5867,6 +6328,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -5882,6 +6344,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -5897,6 +6360,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -5912,6 +6376,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -5927,6 +6392,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -5942,6 +6408,7 @@
         },
         {
           "alias": "Total Time",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -5957,6 +6424,7 @@
         },
         {
           "alias": "Query",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -5974,6 +6442,7 @@
         },
         {
           "alias": "Database",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -5989,6 +6458,7 @@
         },
         {
           "alias": "User",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -6004,6 +6474,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -6059,11 +6530,11 @@
           }
         }
       ],
-      "type": "table"
+      "type": "table-old"
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 16,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "prometheus",
@@ -6075,17 +6546,28 @@
     "list": [
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "localhost",
+          "value": "localhost"
+        },
         "datasource": "prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Server",
         "multi": false,
         "name": "job",
         "options": [],
-        "query": "label_values(sql_settings{col='max_connections'}, job)",
+        "query": {
+          "query": "label_values(sql_settings{col='max_connections'}, job)",
+          "refId": "prometheus-job-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -6095,17 +6577,28 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "11/main",
+          "value": "11/main"
+        },
         "datasource": "prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Cluster",
         "multi": false,
         "name": "cluster",
         "options": [],
-        "query": "label_values(sql_settings{job='$job'}, sql_job)",
+        "query": {
+          "query": "label_values(sql_settings{job='$job'}, sql_job)",
+          "refId": "prometheus-cluster-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -6115,17 +6608,28 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": true,
         "label": "PostgreSQL Port",
         "multi": false,
         "name": "host",
         "options": [],
-        "query": "label_values(sql_settings{job='$job'}, host)",
+        "query": {
+          "query": "label_values(sql_settings{job='$job'}, host)",
+          "refId": "prometheus-host-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -6135,17 +6639,28 @@
       },
       {
         "allValue": "",
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Database",
         "multi": false,
         "name": "datname",
         "options": [],
-        "query": "label_values(sql_pg_stat_database{col='dbsize', host=~'$host', sql_job=~'$cluster'}, datname)",
+        "query": {
+          "query": "label_values(sql_pg_stat_database{col='dbsize', host=~'$host', sql_job=~'$cluster'}, datname)",
+          "refId": "prometheus-datname-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -6158,9 +6673,12 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
+          "selected": false,
           "text": "5m",
           "value": "5m"
         },
+        "description": null,
+        "error": null,
         "hide": 0,
         "label": "Rate Interval",
         "name": "rate_interval",
@@ -6193,21 +6711,33 @@
         ],
         "query": "1m,5m,10m,30m,1h",
         "refresh": 2,
+        "skipUrlSync": false,
         "type": "interval"
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Disk",
         "multi": true,
         "name": "disk",
         "options": [],
-        "query": "label_values(node_disk_written_bytes_total, device)",
+        "query": {
+          "query": "label_values(node_disk_written_bytes_total, device)",
+          "refId": "prometheus-disk-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -6222,6 +6752,8 @@
           "text": "5",
           "value": "5"
         },
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Top k",
@@ -6265,21 +6797,33 @@
           }
         ],
         "query": "1,3,5,10,20,50,100",
+        "skipUrlSync": false,
         "type": "custom"
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Interface",
         "multi": false,
         "name": "interface",
         "options": [],
-        "query": "label_values(node_network_receive_bytes_total, device)",
+        "query": {
+          "query": "label_values(node_network_receive_bytes_total, device)",
+          "refId": "prometheus-interface-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -6289,17 +6833,28 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Filesystem",
         "multi": true,
         "name": "filesystem",
         "options": [],
-        "query": "label_values(node_filesystem_size_bytes{job='$job'}, mountpoint)",
+        "query": {
+          "query": "label_values(node_filesystem_size_bytes{job='$job'}, mountpoint)",
+          "refId": "prometheus-filesystem-Variable-Query"
+        },
         "refresh": 2,
         "regex": "(?!/media).*",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -6309,17 +6864,28 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "prometheus",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Streaming Receiver",
         "multi": false,
         "name": "application_name",
         "options": [],
-        "query": "label_values(sql_pg_stat_replication{host=~'$host', sql_job=~'$cluster'}, application_name)",
+        "query": {
+          "query": "label_values(sql_pg_stat_replication{host=~'$host', sql_job=~'$cluster'}, application_name)",
+          "refId": "prometheus-application_name-Variable-Query"
+        },
         "refresh": 2,
         "regex": "^.+.+",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],

--- a/grafana/postgresql_server_overview.json
+++ b/grafana/postgresql_server_overview.json
@@ -2154,7 +2154,7 @@
           "label": "Cores",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -2243,7 +2243,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -3359,7 +3359,7 @@
           "label": "",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -3835,7 +3835,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -3934,7 +3934,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -4623,7 +4623,7 @@
           "label": "",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -4732,7 +4732,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -4822,7 +4822,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -5106,7 +5106,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -5704,7 +5704,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {

--- a/grafana/postgresql_server_overview.json
+++ b/grafana/postgresql_server_overview.json
@@ -3807,6 +3807,7 @@
         {
           "expr": "max by (datname) (sql_pg_stat_activity{job=~'$job', host=~'$host', sql_job=~'$cluster', col='max_tx_duration', datname=~'$datname'})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{datname}}",
           "refId": "A"
@@ -4303,7 +4304,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($ntop_relations, rate(sql_pg_stat_user_tables{job=~'$job', host=~'$host', sql_job=~'$cluster.*', col='seq_scan', database=~'$datname'}[$rate_interval]))",
+          "expr": "topk($ntop_relations, rate(sql_pg_stat_user_tables{job=~'$job', host=~'$host', sql_job=~'$cluster.*', col='seq_tup_read', database=~'$datname'}[$rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -4316,7 +4317,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Sequential Scans [$rate_interval] (top $ntop_relations) - $datname",
+      "title": "Sequential Scan Tuples [$rate_interval] (top $ntop_relations) - $datname",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -4332,7 +4333,7 @@
       },
       "yaxes": [
         {
-          "format": "ops",
+          "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -4392,11 +4393,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($ntop_relations, rate(sql_pg_stat_user_tables{job=~'$job', host=~'$host', sql_job=~'$cluster.*', col='idx_scan', datname=~'$datname'}[$rate_interval]))",
+          "expr": "topk($ntop_relations, sort_desc((sql_pg_stat_user_tables{job=~'$job', host=~'$host', sql_job=~'$cluster.*', col='seq_tup_read', datname=~'$datname'} > 0 ) / ignoring(col) (sql_pg_stat_user_tables{job=~'$job', host=~'$host', sql_job=~'$cluster.*', col='idx_tup_fetch', datname=~'$datname'} > 0 )))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "idx scans {{schemaname}}.{{relname}} ({{database}})",
+          "legendFormat": "seq/idx scan tuple ratio {{schemaname}}.{{relname}} ({{database}})",
           "metric": "sql_pg_stat_user_tables",
           "refId": "A",
           "step": 40
@@ -4405,7 +4406,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Index Scans [$rate_interval] (top $ntop_relations) - $datname",
+      "title": "Seq/Index Tuple Ratio [$rate_interval] (top $ntop_relations) - $datname",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -4421,7 +4422,7 @@
       },
       "yaxes": [
         {
-          "format": "ops",
+          "format": "none",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/grafana/postgresql_server_overview.json
+++ b/grafana/postgresql_server_overview.json
@@ -4594,16 +4594,24 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "WAL new",
+          "legendFormat": "WAL traffic",
           "metric": "sql_waldistance",
           "refId": "A",
           "step": 60
+        },
+        {
+          "expr": "rate(sql_checkpoints{col=\"buffers\", job=~'$job', host=~'$host', sql_job=~'$cluster'}[$rate_interval]) * 8192",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Checkpoint traffic",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "WAL Traffic [$rate_interval]",
+      "title": "WAL/Checkpoint Traffic [$rate_interval]",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -4684,7 +4692,7 @@
         }
       ],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -4713,6 +4721,18 @@
           "options": {
             "regex": "requested",
             "renamePattern": "requested (explicit, wal or backup-based)"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Time",
+                "requested (explicit, wal or backup-based)",
+                "timed"
+              ]
+            }
           }
         }
       ],

--- a/grafana/postgresql_server_overview.json
+++ b/grafana/postgresql_server_overview.json
@@ -3975,7 +3975,7 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 10,
+        "w": 12,
         "x": 0,
         "y": 87
       },
@@ -3984,7 +3984,7 @@
         "alignAsTable": false,
         "avg": false,
         "current": false,
-        "hideZero": true,
+        "hideZero": false,
         "max": false,
         "min": false,
         "rightSide": false,
@@ -4006,12 +4006,33 @@
       "steppedLine": false,
       "targets": [
         {
+          "expr": "rate(sql_pg_stat_database{job='$job', host=~'$host', sql_job=~'$cluster.*', datname=~'$datname', col='tup_returned'}[$rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "instant": "",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Select (table scan) {{datname}}",
+          "refId": "A",
+          "step": 120
+        },
+        {
+          "expr": "rate(sql_pg_stat_database{job='$job', host=~'$host', sql_job=~'$cluster.*', datname=~'$datname', col='tup_fetched'}[$rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Select (index scan) {{datname}}",
+          "refId": "B",
+          "step": 120
+        },
+        {
           "expr": "rate(sql_pg_stat_database{job='$job', host=~'$host', sql_job=~'$cluster.*', datname=~'$datname', col='tup_inserted'}[$rate_interval])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "Insert {{datname}}",
-          "refId": "B",
+          "refId": "C",
           "step": 120
         },
         {
@@ -4020,7 +4041,7 @@
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "Update {{datname}}",
-          "refId": "C",
+          "refId": "D",
           "step": 120
         },
         {
@@ -4029,14 +4050,14 @@
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "Delete {{datname}}",
-          "refId": "D",
+          "refId": "E",
           "step": 120
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Inserts Updates Deletes [$rate_interval]",
+      "title": "Read / Change Stats [$rate_interval] - ($datname)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -4052,8 +4073,8 @@
       },
       "yaxes": [
         {
-          "format": "ops",
-          "label": "",
+          "format": "short",
+          "label": "Rows",
           "logBase": 1,
           "max": null,
           "min": "0",
@@ -4082,8 +4103,8 @@
       "fill": 5,
       "gridPos": {
         "h": 7,
-        "w": 7,
-        "x": 10,
+        "w": 6,
+        "x": 12,
         "y": 87
       },
       "id": 16,
@@ -4171,8 +4192,8 @@
       "fill": 5,
       "gridPos": {
         "h": 7,
-        "w": 7,
-        "x": 17,
+        "w": 6,
+        "x": 18,
         "y": 87
       },
       "id": 12,

--- a/grafana/postgresql_server_overview.json
+++ b/grafana/postgresql_server_overview.json
@@ -4455,7 +4455,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 14,
         "x": 0,
         "y": 89
       },
@@ -4510,40 +4510,13 @@
           "legendFormat": "Select (index scan) {{datname}}",
           "refId": "B",
           "step": 120
-        },
-        {
-          "expr": "rate(sql_pg_stat_database{job='$job', host=~'$host', sql_job=~'$cluster.*', datname=~'$datname', col='tup_inserted'}[$rate_interval])",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "Insert {{datname}}",
-          "refId": "C",
-          "step": 120
-        },
-        {
-          "expr": "rate(sql_pg_stat_database{job='$job', host=~'$host', sql_job=~'$cluster.*', datname=~'$datname', col='tup_updated'}[$rate_interval])",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "Update {{datname}}",
-          "refId": "D",
-          "step": 120
-        },
-        {
-          "expr": "rate(sql_pg_stat_database{job='$job', host=~'$host', sql_job=~'$cluster.*', datname=~'$datname', col='tup_deleted'}[$rate_interval])",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "Delete {{datname}}",
-          "refId": "E",
-          "step": 120
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Read / Change Stats [$rate_interval] - ($datname)",
+      "title": "Read Stats [$rate_interval] - $datname",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -4559,6 +4532,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:3090",
           "format": "short",
           "label": "Rows",
           "logBase": 1,
@@ -4567,6 +4541,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:3091",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -4596,8 +4571,8 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 6,
-        "x": 12,
+        "w": 10,
+        "x": 14,
         "y": 89
       },
       "hiddenSeries": false,
@@ -4694,13 +4669,135 @@
         },
         "overrides": []
       },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 14,
+        "x": 0,
+        "y": 96
+      },
+      "hiddenSeries": false,
+      "id": 122,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(sql_pg_stat_database{job='$job', host=~'$host', sql_job=~'$cluster.*', datname=~'$datname', col='tup_inserted'}[$rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "Insert {{datname}}",
+          "refId": "A",
+          "step": 120
+        },
+        {
+          "expr": "rate(sql_pg_stat_database{job='$job', host=~'$host', sql_job=~'$cluster.*', datname=~'$datname', col='tup_updated'}[$rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "Update {{datname}}",
+          "refId": "B",
+          "step": 120
+        },
+        {
+          "expr": "rate(sql_pg_stat_database{job='$job', host=~'$host', sql_job=~'$cluster.*', datname=~'$datname', col='tup_deleted'}[$rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "Delete {{datname}}",
+          "refId": "C",
+          "step": 120
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Change Stats [$rate_interval] - $datname",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:3016",
+          "format": "short",
+          "label": "Rows",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:3017",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 5,
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 89
+        "w": 5,
+        "x": 14,
+        "y": 96
       },
       "hiddenSeries": false,
       "id": 12,
@@ -4785,13 +4882,117 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 19,
+        "y": 96
+      },
+      "hiddenSeries": false,
+      "id": 123,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.3",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(sql_pg_stat_database{job=~'$job', host=~'$host', sql_job=~'$cluster.*', col='temp_bytes', database=~'$datname'}[$rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "temp bytes {{database}}",
+          "metric": "",
+          "refId": "B",
+          "step": 40
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Temp Files  [$rate_interval] - $datname",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:3200",
+          "format": "binBps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:3201",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 96
+        "y": 103
       },
       "id": 77,
       "panels": [],
@@ -4817,7 +5018,7 @@
         "h": 8,
         "w": 9,
         "x": 0,
-        "y": 97
+        "y": 104
       },
       "hiddenSeries": false,
       "id": 5,
@@ -4919,7 +5120,7 @@
         "h": 8,
         "w": 9,
         "x": 9,
-        "y": 97
+        "y": 104
       },
       "hiddenSeries": false,
       "id": 55,
@@ -5021,7 +5222,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 97
+        "y": 104
       },
       "hiddenSeries": false,
       "id": 27,
@@ -5116,7 +5317,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 105
+        "y": 112
       },
       "id": 80,
       "panels": [],
@@ -5142,7 +5343,7 @@
         "h": 7,
         "w": 7,
         "x": 0,
-        "y": 106
+        "y": 113
       },
       "hiddenSeries": false,
       "id": 26,
@@ -5254,7 +5455,7 @@
         "h": 7,
         "w": 9,
         "x": 7,
-        "y": 106
+        "y": 113
       },
       "hiddenSeries": false,
       "id": 29,
@@ -5390,7 +5591,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 106
+        "y": 113
       },
       "hiddenSeries": false,
       "id": 31,
@@ -5479,7 +5680,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 113
+        "y": 120
       },
       "id": 81,
       "panels": [],
@@ -5505,7 +5706,7 @@
         "h": 7,
         "w": 10,
         "x": 0,
-        "y": 114
+        "y": 121
       },
       "hiddenSeries": false,
       "id": 30,
@@ -5609,7 +5810,7 @@
         "h": 7,
         "w": 9,
         "x": 10,
-        "y": 114
+        "y": 121
       },
       "hiddenSeries": false,
       "id": 53,
@@ -5712,7 +5913,7 @@
         "h": 7,
         "w": 5,
         "x": 19,
-        "y": 114
+        "y": 121
       },
       "hiddenSeries": false,
       "id": 54,
@@ -5803,7 +6004,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 121
+        "y": 128
       },
       "id": 85,
       "panels": [],
@@ -5830,7 +6031,7 @@
         "h": 7,
         "w": 7,
         "x": 0,
-        "y": 122
+        "y": 129
       },
       "hiddenSeries": false,
       "id": 51,
@@ -5931,7 +6132,7 @@
         "h": 7,
         "w": 7,
         "x": 7,
-        "y": 122
+        "y": 129
       },
       "hiddenSeries": false,
       "id": 47,
@@ -6037,7 +6238,7 @@
         "h": 7,
         "w": 10,
         "x": 14,
-        "y": 122
+        "y": 129
       },
       "hiddenSeries": false,
       "id": 61,
@@ -6154,7 +6355,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 129
+        "y": 136
       },
       "id": 83,
       "panels": [],
@@ -6181,7 +6382,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 130
+        "y": 137
       },
       "hiddenSeries": false,
       "id": 57,
@@ -6285,7 +6486,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 130
+        "y": 137
       },
       "hiddenSeries": false,
       "id": 98,
@@ -6389,7 +6590,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 130
+        "y": 137
       },
       "hiddenSeries": false,
       "id": 59,
@@ -6489,7 +6690,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 138
+        "y": 145
       },
       "id": 58,
       "links": [],

--- a/grafana/postgresql_server_overview.json
+++ b/grafana/postgresql_server_overview.json
@@ -974,7 +974,19 @@
           },
           "unit": "none"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "requested (explicit, wal or backup-based)"
+            },
+            "properties": [
+              {
+                "id": "displayName"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 3,
@@ -4659,13 +4671,24 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:795",
+          "alias": "requested (explicit, wal or backup-based)",
+          "color": "#FADE2A"
+        },
+        {
+          "$$hashKey": "object:803",
+          "alias": "timed",
+          "color": "#73BF69"
+        }
+      ],
       "spaceLength": 10,
       "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "60 * rate(sql_checkpoints{job=~'$job', host=~'$host', sql_job=~'$cluster'}[$rate_interval])",
+          "expr": "60 * rate(sql_checkpoints{job=~'$job', host=~'$host', sql_job=~'$cluster'}[90s])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -4678,12 +4701,21 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Checkpoints per Minute [$rate_interval]",
+      "title": "Checkpoints per Minute",
       "tooltip": {
         "shared": true,
         "sort": 0,
         "value_type": "individual"
       },
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "requested",
+            "renamePattern": "requested (explicit, wal or backup-based)"
+          }
+        }
+      ],
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -4694,6 +4726,8 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:673",
+          "decimals": 0,
           "format": "opm",
           "label": null,
           "logBase": 1,

--- a/grafana/postgresql_server_overview.json
+++ b/grafana/postgresql_server_overview.json
@@ -2800,13 +2800,6 @@
       "renderer": "flot",
       "repeat": "filesystem",
       "repeatDirection": "h",
-      "scopedVars": {
-        "filesystem": {
-          "selected": false,
-          "text": "/",
-          "value": "/"
-        }
-      },
       "seriesOverrides": [
         {
           "alias": "/Used.*$/",
@@ -4005,7 +3998,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 9,
+        "w": 7,
         "x": 0,
         "y": 81
       },
@@ -4083,6 +4076,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1487",
           "format": "ops",
           "label": null,
           "logBase": 1,
@@ -4091,6 +4085,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:1488",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -4120,8 +4115,8 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 8,
-        "x": 9,
+        "w": 5,
+        "x": 7,
         "y": 81
       },
       "hiddenSeries": false,
@@ -4181,6 +4176,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1565",
           "format": "s",
           "label": null,
           "logBase": 1,
@@ -4189,6 +4185,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:1566",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -4217,12 +4214,12 @@
         },
         "overrides": []
       },
-      "fill": 3,
+      "fill": 1,
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 7,
-        "x": 17,
+        "w": 6,
+        "x": 12,
         "y": 81
       },
       "hiddenSeries": false,
@@ -4237,7 +4234,7 @@
         "values": false
       },
       "lines": true,
-      "linewidth": 2,
+      "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
       "options": {
@@ -4250,12 +4247,14 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
+          "$$hashKey": "object:1299",
           "alias": "ExclusiveLock",
           "color": "#BF1B00",
           "fill": 6,
           "linewidth": 4
         },
         {
+          "$$hashKey": "object:1300",
           "alias": "AccessExclusiveLock",
           "color": "#58140C"
         }
@@ -4293,6 +4292,8 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1317",
+          "decimals": 0,
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -4301,6 +4302,115 @@
           "show": true
         },
         {
+          "$$hashKey": "object:1318",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 81
+      },
+      "hiddenSeries": false,
+      "id": 121,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.3",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1071",
+          "alias": "/.*/",
+          "color": "#FADE2A"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(sql_pg_stat_database{job=~'$job', host=~'$host', sql_job=~'$cluster', col='deadlocks', datname=~'$datname'}[90s]) * 60",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "deadlocks {{datname}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Deadlocks -$datname",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1085",
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1086",
           "format": "short",
           "label": null,
           "logBase": 1,

--- a/sql-exporter/queries.yml
+++ b/sql-exporter/queries.yml
@@ -15,21 +15,85 @@
 - name: "settings"
   help: "PostgreSQL settings"
   scope: cluster
+  min_version: 9.5
+  max_version: 10
   labels:
     - "settings"
   values:
+    - "data_checksums"
     - "max_connections"
     - "autovacuum_freeze_max_age"
     - "superuser_reserved_connections"
     - "max_wal_senders"
     - "max_prepared_transactions"
+    - "max_worker_processes"
+    - "random_page_cost"
+    - "seq_page_cost"
+    - "checkpoint_timeout"
+    - "work_mem"
+    - "maintenance_work_mem"
+    - "shared_buffers"
+    - "effective_cache_size"
+    - "max_wal_size"
   query: >-
           SELECT
+          current_setting('data_checksums')::bool::int::float AS data_checksums,
           current_setting('max_connections')::float AS max_connections,
           current_setting('autovacuum_freeze_max_age')::float AS autovacuum_freeze_max_age,
           current_setting('superuser_reserved_connections')::float AS superuser_reserved_connections,
           current_setting('max_wal_senders')::float AS max_wal_senders,
-          current_setting('max_prepared_transactions')::float AS max_prepared_transactions
+          current_setting('max_prepared_transactions')::float AS max_prepared_transactions,
+          current_setting('max_worker_processes')::float AS max_worker_processes,
+          current_setting('random_page_cost')::float AS random_page_cost,
+          current_setting('seq_page_cost')::float AS seq_page_cost,
+          (SELECT setting FROM pg_settings WHERE name = 'checkpoint_timeout') AS checkpoint_timeout,
+          pg_size_bytes(current_setting('work_mem'))::float AS work_mem,
+          pg_size_bytes(current_setting('maintenance_work_mem'))::float AS maintenance_work_mem,
+          pg_size_bytes(current_setting('shared_buffers'))::float AS shared_buffers,
+          pg_size_bytes(current_setting('effective_cache_size'))::float AS effective_cache_size,
+          pg_size_bytes(current_setting('max_wal_size'))::float AS max_wal_size
+
+- name: "settings"
+  help: "PostgreSQL settings"
+  scope: cluster
+  min_version: 11
+  labels:
+    - "settings"
+  values:
+    - "data_checksums"
+    - "jit"
+    - "max_connections"
+    - "autovacuum_freeze_max_age"
+    - "superuser_reserved_connections"
+    - "max_wal_senders"
+    - "max_prepared_transactions"
+    - "max_worker_processes"
+    - "random_page_cost"
+    - "seq_page_cost"
+    - "checkpoint_timeout"
+    - "work_mem"
+    - "maintenance_work_mem"
+    - "shared_buffers"
+    - "effective_cache_size"
+    - "max_wal_size"
+  query: >-
+          SELECT
+          current_setting('data_checksums')::bool::int::float AS data_checksums,
+          current_setting('jit')::bool::int::float AS jit,
+          current_setting('max_connections')::float AS max_connections,
+          current_setting('autovacuum_freeze_max_age')::float AS autovacuum_freeze_max_age,
+          current_setting('superuser_reserved_connections')::float AS superuser_reserved_connections,
+          current_setting('max_wal_senders')::float AS max_wal_senders,
+          current_setting('max_prepared_transactions')::float AS max_prepared_transactions,
+          current_setting('max_worker_processes')::float AS max_worker_processes,
+          current_setting('random_page_cost')::float AS random_page_cost,
+          current_setting('seq_page_cost')::float AS seq_page_cost,
+          (SELECT setting FROM pg_settings WHERE name = 'checkpoint_timeout') AS checkpoint_timeout,
+          pg_size_bytes(current_setting('work_mem'))::float AS work_mem,
+          pg_size_bytes(current_setting('maintenance_work_mem'))::float AS maintenance_work_mem,
+          pg_size_bytes(current_setting('shared_buffers'))::float AS shared_buffers,
+          pg_size_bytes(current_setting('effective_cache_size'))::float AS effective_cache_size,
+          pg_size_bytes(current_setting('max_wal_size'))::float AS max_wal_size
 
 - name: "pg_locks"
   help: "locks held"

--- a/sql-exporter/queries.yml
+++ b/sql-exporter/queries.yml
@@ -37,6 +37,7 @@
   help: "database statistics"
   scope: cluster
   min_version: 9.2
+  max_version: 11
   type: "counter"
   labels:
     - "datname"
@@ -79,6 +80,59 @@
           blk_read_time,
           blk_write_time,
           age(d.datfrozenxid) AS freeze_age,
+          pg_database_size(s.datname)::float AS dbsize
+          FROM pg_stat_database s
+          LEFT JOIN pg_database d ON d.datname = s.datname
+          WHERE NOT s.datname ~ '^template(0|1)$'
+
+- name: "pg_stat_database"
+  help: "database statistics"
+  scope: cluster
+  min_version: 12
+  type: "counter"
+  labels:
+    - "datname"
+  values:
+    - "numbackends:count"
+    - "xact_commit"
+    - "xact_rollback"
+    - "blks_read"
+    - "blks_hit"
+    - "tup_returned"
+    - "tup_fetched"
+    - "tup_inserted"
+    - "tup_updated"
+    - "tup_deleted"
+    - "conflicts"
+    - "temp_files"
+    - "temp_bytes"
+    - "deadlocks"
+    - "blk_read_time"
+    - "blk_write_time"
+    - "freeze_age"
+    - "checksum_failures"
+    - "dbsize"
+  query: >-
+          SELECT
+          s.datname::text,
+          numbackends::float,
+          xact_commit::float,
+          xact_rollback::float,
+          blks_read::float,
+          blks_hit::float,
+          tup_returned::float,
+          tup_fetched::float,
+          tup_inserted::float,
+          tup_updated::float,
+          tup_deleted::float,
+          conflicts::float,
+          temp_files::float,
+          temp_bytes::float,
+          deadlocks::float,
+          blk_read_time,
+          blk_write_time,
+          age(d.datfrozenxid) AS freeze_age,
+          coalesce(checksum_failures::float, 0) AS checksum_failures,
           pg_database_size(s.datname)::float AS dbsize
           FROM pg_stat_database s
           LEFT JOIN pg_database d ON d.datname = s.datname

--- a/sql-exporter/queries.yml
+++ b/sql-exporter/queries.yml
@@ -1,5 +1,17 @@
 # queries run once per cluster (via the 'postgres' database)
 
+- name: "server"
+  help: "Server version and start time"
+  scope: cluster
+  labels:
+    - "server_version"
+  values:
+    - "server_start_time"
+  query: >-
+          SELECT
+          split_part(current_setting('server_version'), ' ', 1) AS server_version,
+          extract(epoch FROM pg_postmaster_start_time())::float AS server_start_time
+
 - name: "settings"
   help: "PostgreSQL settings"
   scope: cluster

--- a/sql-exporter/wal.yml
+++ b/sql-exporter/wal.yml
@@ -1,15 +1,17 @@
 # queries run once per cluster (via the 'postgres' database)
 
 - name: "checkpoints"
-  help: "requested and timed checkpoints"
+  help: "requested/timed checkpoints and checkpoint buffers"
   scope: cluster
   values:
     - "timed"
     - "requested"
+    - "buffers"
   query: >-
           SELECT
           pg_stat_get_bgwriter_timed_checkpoints() timed,
-          pg_stat_get_bgwriter_requested_checkpoints() requested
+          pg_stat_get_bgwriter_requested_checkpoints() requested,
+          pg_stat_get_bgwriter_buf_written_checkpoints() buffers
 
 - name: "LastCheckpointDistance"
   help: "distance to the last checkpoint"


### PR DESCRIPTION
## Grafana dashboard updates

-  Add settings panels at the top
- Change Top Statements by Total Time table to use chosen time range
- Add legend to Statements panels and adjust height accordingly
- Update Checkpoints per Minute panel
- Add Deadlocks panel to Transactions and Locks
- Add Temp Files panel
- Add Checkpoint traffic to WAL traffic panel
- Update Connections panels
- Update Table Scans panels to report SeqScan tuples and SeqScan to Index Scan ratio
- Add Select table/index scans as Read Stats panel
- Misc layout and display fixes/improvements

## sql-exporter query updates

- Add checksum_failures to pg_stat_database metrics
- Add cluster query for server version and start time
- Add additional settings: This adds some memory-based settings (shared_buffers, work_mem, maintenance_work_mem, effective_cache_size and max_wal_size), as well as some notable settings one might want to expose e.g. in Grafana dashboards like data_checksums, jit (v11+), max_worker_processes, random_page_cost, seq_page_cost and checkpoint_timeout).
- Add buffers to checkpoints query

![monitoring_upgrades](https://github.com/credativ/elephant-shed/assets/1670301/54bcdf64-499d-42a3-a282-1a29b18afe34)
