### PR TITLE
sql-exporter: only generate instant job if there are instant queries

### DIFF
--- a/sql-exporter/update-prometheus-sql-exporter-config
+++ b/sql-exporter/update-prometheus-sql-exporter-config
@@ -52,10 +52,12 @@ sub push_queries_as_jobs($$$)
     }
   }
 
-  my $instant_job = dclone($job_settings);
-  $instant_job->{interval} = 0;
-  $instant_job->{queries} = \@instant;
-  push @$jobs, $instant_job;
+  if (@instant) {
+    my $instant_job = dclone($job_settings);
+    $instant_job->{interval} = 0;
+    $instant_job->{queries} = \@instant;
+    push @$jobs, $instant_job;
+  }
 }
 
 my $queries_directory = $ARGV[0] // die "No directory for *.yml query files specified";


### PR DESCRIPTION
When all per-database queries are filtered in a given database, the config script would still generate a connection to the database with an empty list of jobs (which would then prevent dropping the database).